### PR TITLE
Minor optimization to Reset

### DIFF
--- a/src/AsyncResetEvents/AsyncManualResetEvent.cs
+++ b/src/AsyncResetEvents/AsyncManualResetEvent.cs
@@ -80,12 +80,13 @@ public sealed class AsyncManualResetEvent
     {
         // if the task is completed (aka if the event needs to be reset),
         // swaps the signaled task completion source with a new instance
+        TaskCompletionSource<bool>? newTcs = null;
         while (true) {
             var tcs = _taskCompletionSource;
-            if (!tcs.Task.IsCompleted || Interlocked.CompareExchange(
-                ref _taskCompletionSource,
-                new TaskCompletionSource<bool>(),
-                tcs) == tcs)
+            if (!tcs.Task.IsCompleted)
+                return;
+            newTcs ??= new TaskCompletionSource<bool>();
+            if (Interlocked.CompareExchange(ref _taskCompletionSource, newTcs, tcs) == tcs)
                 return;
         }
     }


### PR DESCRIPTION
- Does not allocate new `TaskCompletionSource` if unnecessary
- Does not repeatedly allocate new `TaskCompletionSource` for second loop if there is contention between threads