### PR TITLE
Add timeout and cancellation tokens to AsyncDelegatePump

### DIFF
--- a/src/AsyncResetEvents/AsyncAutoResetEvent.cs
+++ b/src/AsyncResetEvents/AsyncAutoResetEvent.cs
@@ -127,6 +127,7 @@ public sealed class AsyncAutoResetEvent
 #endif
     }
 
+#if !NET6_0_OR_GREATER
     private sealed class TaskContinuationState
     {
         public Task Task { get; }
@@ -138,6 +139,7 @@ public sealed class AsyncAutoResetEvent
             AsyncAutoResetEvent = asyncAutoResetEvent;
         }
     }
+#endif
 
     /// <summary>
     /// Returns a task that will complete when the reset event has been signaled.

--- a/src/AsyncResetEvents/AsyncMessagePump.cs
+++ b/src/AsyncResetEvents/AsyncMessagePump.cs
@@ -123,7 +123,9 @@ public class AsyncMessagePump<T>
                 var message = messageTuple.Delegate != null
                     ? await messageTuple.Delegate.ConfigureAwait(false)
                     : messageTuple.Value!;
-                await _callback(message).ConfigureAwait(false);
+                var callbackTask = _callback(message);
+                if (callbackTask != null)
+                    await callbackTask.ConfigureAwait(false);
             } catch (Exception ex) {
                 try {
                     await HandleErrorAsync(ex).ConfigureAwait(false);

--- a/src/AsyncResetEvents/AsyncMessagePump.cs
+++ b/src/AsyncResetEvents/AsyncMessagePump.cs
@@ -33,10 +33,6 @@ public class AsyncMessagePump<T>
     private TaskCompletionSource<bool>? _drainTask;
 #endif
 
-#if NETSTANDARD1_0
-    private static readonly Task _completedTask = Task.FromResult<byte>(0);
-#endif
-
     /// <summary>
     /// Initializes a new instances with the specified asynchronous callback delegate.
     /// </summary>
@@ -55,7 +51,7 @@ public class AsyncMessagePump<T>
         _callback = message => {
             callback(message);
 #if NETSTANDARD1_0
-            return _completedTask;
+            return DelegateTuple.CompletedTask;
 #else
             return Task.CompletedTask;
 #endif
@@ -167,7 +163,7 @@ public class AsyncMessagePump<T>
         lock (_queue) {
             if (_queue.Count == 0)
 #if NETSTANDARD1_0
-                return _completedTask;
+                return DelegateTuple.CompletedTask;
 #else
                 return Task.CompletedTask;
 #endif
@@ -181,7 +177,7 @@ public class AsyncMessagePump<T>
     /// </summary>
     protected virtual Task HandleErrorAsync(Exception exception)
 #if NETSTANDARD1_0
-        => _completedTask;
+        => DelegateTuple.CompletedTask;
 #else
         => Task.CompletedTask;
 #endif

--- a/src/AsyncResetEvents/DelegateTuple.cs
+++ b/src/AsyncResetEvents/DelegateTuple.cs
@@ -1,0 +1,110 @@
+namespace Shane32.AsyncResetEvents;
+
+/// <summary>
+/// Holds state information for <see cref="AsyncDelegatePump"/>.
+/// </summary>
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+internal sealed class DelegateTuple : IDelegateTuple
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+{
+    private readonly Func<Task> _action;
+
+#if NET5_0_OR_GREATER
+    private readonly TaskCompletionSource _taskCompletionSource = new();
+#else
+    private readonly TaskCompletionSource<byte> _taskCompletionSource = new();
+#endif
+
+    private readonly CancellationTokenRegistration? _cancellationTokenRegistration;
+#if !NETSTANDARD1_0
+    private readonly Timer? _timer;
+#endif
+    private int _started;
+
+#if NETSTANDARD1_0
+    internal static readonly Task CompletedTask = Task.FromResult<byte>(0);
+#endif
+
+    internal Task Task => _taskCompletionSource.Task;
+
+    public DelegateTuple(Func<Task> action, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (timeout == TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+        }
+
+        _action = action;
+
+        if (cancellationToken.CanBeCanceled) {
+            // register cancellation callback that will cancel the task if it hasn't started yet
+            _cancellationTokenRegistration = cancellationToken.Register(static state => {
+                var info = (DelegateTuple)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+#if !NETSTANDARD1_0
+                    info._timer?.Dispose();
+#endif
+                    // we don't need to dispose the registration because it's already been invoked
+                    info._taskCompletionSource.SetCanceled();
+                }
+            }, this);
+        }
+
+        if (timeout != Timeout.InfiniteTimeSpan) {
+#if !NETSTANDARD1_0
+            _timer = new Timer(static state => {
+                var info = (DelegateTuple)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+                    info._timer?.Dispose();
+                    info._cancellationTokenRegistration?.Dispose();
+                    info._taskCompletionSource.SetException(new TimeoutException());
+                }
+            }, this, timeout, Timeout.InfiniteTimeSpan);
+#else
+            Task.Delay(timeout, default).ContinueWith(static (t, state) => {
+                var info = (DelegateTuple)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+                    info._cancellationTokenRegistration?.Dispose();
+                    info._taskCompletionSource.SetException(new TimeoutException());
+                }
+            }, this, default(CancellationToken));
+#endif
+        }
+    }
+
+    public Task ExecuteAsync()
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1) {
+            // already canceled, so do nothing
+#if NETSTANDARD1_0
+            return CompletedTask;
+#else
+            return Task.CompletedTask;
+#endif
+        }
+#if !NETSTANDARD1_0
+        _timer?.Dispose();
+#endif
+        _cancellationTokenRegistration?.Dispose();
+        Task task;
+        try {
+            task = _action.Invoke();
+        } catch (Exception ex) {
+            _taskCompletionSource.SetException(ex);
+            throw;
+        }
+        task.ContinueWith(static (task2, state) => {
+            var info = (DelegateTuple)state!;
+            if (task2.IsFaulted)
+                info._taskCompletionSource.SetException(task2.Exception!.GetBaseException());
+            else if (task2.IsCanceled)
+                info._taskCompletionSource.SetCanceled();
+            else
+#if NET5_0_OR_GREATER
+                info._taskCompletionSource.SetResult();
+#else
+                info._taskCompletionSource.SetResult(0);
+#endif
+        }, this, TaskContinuationOptions.ExecuteSynchronously);
+        return task;
+    }
+}

--- a/src/AsyncResetEvents/DelegateTupleT.cs
+++ b/src/AsyncResetEvents/DelegateTupleT.cs
@@ -1,0 +1,98 @@
+namespace Shane32.AsyncResetEvents;
+
+/// <summary>
+/// Holds state information for <see cref="AsyncDelegatePump"/>.
+/// </summary>
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+internal sealed class DelegateTuple<T> : IDelegateTuple
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+{
+    private readonly Func<Task<T>> _action;
+
+    private readonly TaskCompletionSource<T> _taskCompletionSource = new();
+
+    private readonly CancellationTokenRegistration? _cancellationTokenRegistration;
+#if !NETSTANDARD1_0
+    private readonly Timer? _timer;
+#endif
+    private int _started;
+
+    internal Task<T> Task => _taskCompletionSource.Task;
+
+    public DelegateTuple(Func<Task<T>> action, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (timeout == TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be greater than zero.");
+        }
+
+        _action = action;
+
+        if (cancellationToken.CanBeCanceled) {
+            // register cancellation callback that will cancel the task if it hasn't started yet
+            _cancellationTokenRegistration = cancellationToken.Register(static state => {
+                var info = (DelegateTuple<T>)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+#if !NETSTANDARD1_0
+                    info._timer?.Dispose();
+#endif
+                    // we don't need to dispose the registration because it's already been invoked
+                    info._taskCompletionSource.SetCanceled();
+                }
+            }, this);
+        }
+
+        if (timeout != Timeout.InfiniteTimeSpan) {
+#if !NETSTANDARD1_0
+            _timer = new Timer(static state => {
+                var info = (DelegateTuple<T>)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+                    info._timer?.Dispose();
+                    info._cancellationTokenRegistration?.Dispose();
+                    info._taskCompletionSource.SetException(new TimeoutException());
+                }
+            }, this, timeout, Timeout.InfiniteTimeSpan);
+#else
+            System.Threading.Tasks.Task.Delay(timeout, default).ContinueWith(static (t, state) => {
+                var info = (DelegateTuple<T>)state!;
+                if (Interlocked.Exchange(ref info._started, 1) == 0) {
+                    info._cancellationTokenRegistration?.Dispose();
+                    info._taskCompletionSource.SetException(new TimeoutException());
+                }
+            }, this, default(CancellationToken));
+#endif
+        }
+    }
+
+    public Task ExecuteAsync()
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1) {
+            // already canceled, so do nothing
+#if NETSTANDARD1_0
+            return DelegateTuple.CompletedTask;
+#else
+            return System.Threading.Tasks.Task.CompletedTask;
+#endif
+        }
+#if !NETSTANDARD1_0
+        _timer?.Dispose();
+#endif
+        _cancellationTokenRegistration?.Dispose();
+        Task<T> task;
+        try {
+            task = _action.Invoke();
+        } catch (Exception ex) {
+            _taskCompletionSource.SetException(ex);
+            throw;
+        }
+        task.ContinueWith(static (task2, state) => {
+            var info = (DelegateTuple<T>)state!;
+            if (task2.IsFaulted)
+                info._taskCompletionSource.SetException(task2.Exception!.GetBaseException());
+            else if (task2.IsCanceled)
+                info._taskCompletionSource.SetCanceled();
+            else
+                info._taskCompletionSource.SetResult(task2.Result);
+        }, this, TaskContinuationOptions.ExecuteSynchronously);
+        return task;
+    }
+}

--- a/src/AsyncResetEvents/IDelegateTuple.cs
+++ b/src/AsyncResetEvents/IDelegateTuple.cs
@@ -1,0 +1,12 @@
+namespace Shane32.AsyncResetEvents;
+
+/// <summary>
+/// An internal interface for <see cref="AsyncDelegatePump"/>.
+/// </summary>
+public interface IDelegateTuple
+{
+    /// <summary>
+    /// Executes the delegate.
+    /// </summary>
+    Task ExecuteAsync();
+}


### PR DESCRIPTION
Adds:
- `Task SendAsync(Func<Task> action, TimeSpan timeout, CancellationToken token)`
- `Task<T> SendAsync<T>(Func<Task<T>> action, TimeSpan timeout, CancellationToken token)`

Inheritance structure for `AsyncDelegatePump` has been changed for better performance