### PR TITLE
Add execution context awareness

### DIFF
--- a/src/AsyncResetEvents/AsyncDelegatePump.cs
+++ b/src/AsyncResetEvents/AsyncDelegatePump.cs
@@ -16,7 +16,8 @@ public class AsyncDelegatePump : AsyncMessagePump<IDelegateTuple>
 
     /// <summary>
     /// This setting has no effect within <see cref="AsyncDelegatePump"/>.
-    /// The execution context is always cloned from the posting thread onto the delegate.
+    /// The execution context is always cloned from the posting thread onto the delegate,
+    /// except when running on the .NET Standard 1.0 or .NET Standard 1.3 TFMs.
     /// </summary>
     public override bool SuppressAsyncFlow {
         get => false;

--- a/src/Tests/AsyncDelegatePumpTests.cs
+++ b/src/Tests/AsyncDelegatePumpTests.cs
@@ -21,16 +21,22 @@ public class AsyncDelegatePumpTests
     [Fact]
     public async Task Basic()
     {
+        var al = new AsyncLocal<string?>();
+        al.Value = "a";
         _pump.Post(async () => {
             await Task.Delay(100);
+            Assert.Equal("a", al.Value);
             WriteLine("100");
         });
+        al.Value = "b";
         _pump.Post(async () => {
             Verify("100 ");
             await Task.Delay(1);
+            Assert.Equal("b", al.Value);
             WriteLine("1");
             _reset.Set();
         });
+        al.Value = null;
         Verify("");
         await _reset.WaitAsync();
         Verify("100 1 ");


### PR DESCRIPTION
- AsyncAutoResetEvent: n/a
- AsyncManualResetEvent: n/a
- AsyncMessagePump: default behavior as before; opt-in to clear execution context when the callback is run
- AsyncDelegatePump: execution context is always copied to the posted/sent delegates